### PR TITLE
Update exports of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "files": [
     "dist"
   ],
-  "types": "dist/usePaginator.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/usePaginator.d.ts",
       "import": "./dist/vue-use-paginator.es.js",
       "require": "./dist/vue-use-paginator.umd.js"
     }


### PR DESCRIPTION
In order to fix:
Could not find a declaration file for module 'vue-use-paginator'. '/node_modules/vue-use-paginator/dist/vue-use-paginator.es.js' implicitly has an 'any' type.
There are types at '/node_modules/vue-use-paginator/dist/usePaginator.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vue-use-paginator' library may need to update its package.json or typings.